### PR TITLE
Adding OTP VPN setup video instructions (windows).

### DIFF
--- a/src/Instructions/VideoInstructions.js
+++ b/src/Instructions/VideoInstructions.js
@@ -1,0 +1,30 @@
+import React, { Component } from "react";
+
+const youtubeLink = {
+  'Windows 7, Vista and XP': "https://www.youtube.com/embed/wGWrXofjIyo",
+  'Windows 10 and 8.x': "https://www.youtube.com/embed/kq1NFCbR1wI"
+};
+
+export default class VideoInstructions extends Component {
+  render() {
+    return (
+      <div className="jumbotron">
+        <h1 className="display-4">Video setup for {this.props.platform}</h1>
+        <p className="lead">
+          Follow the video installation below to configure a VPN connection to your DAppNode
+        </p>
+        <div className="videoWrapper">
+          <iframe
+            title="Video setup instructions"
+            type="text\/html"
+            width="640"
+            height="360"
+            frameBorder="0"
+            allowFullScreen
+            src={youtubeLink[this.props.platform]}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/Instructions/Windows10.js
+++ b/src/Instructions/Windows10.js
@@ -1,11 +1,14 @@
 import React, { Component } from "react";
 import Credential from "./Credential";
+import VideoInstructions from "./VideoInstructions";
 
 export default class Windows10 extends Component {
   render() {
     // <Credential tag={'server'}/>
     return (
       <div>
+        <VideoInstructions platform={"Windows 10 and 8.x"} />
+
         <h4>Windows 10 and 8.x setup guide</h4>
         <hr className="my-4" />
         <ol className="ListInstructions">

--- a/src/Instructions/Windows7.js
+++ b/src/Instructions/Windows7.js
@@ -1,11 +1,14 @@
 import React, { Component } from "react";
 import Credential from "./Credential";
+import VideoInstructions from "./VideoInstructions";
 
 export default class Windows7 extends Component {
   render() {
     // <Credential tag={'server'}/>
     return (
       <div>
+        <VideoInstructions platform={"Windows 7, Vista and XP"} />
+
         <h4>Windows 7, Vista and XP setup guide</h4>
         <hr className="my-4" />
         <ol className="ListInstructions">


### PR DESCRIPTION
Hey there!

This PR resolves [DAppNode Issue #36](https://github.com/dappnode/DAppNode/issues/36) regarding the need for setup instruction videos for the Windows platform. 

**Work Completed:**
A new react source file was made. This is nearly identical to the pre-existing `AutomaticSetup.js` but removes the unnecessary imports and references. It can be found at `VideoInstructions.js`. The `Windows7.js` and `Windows10.js` files have been edited to import `VideoInstructions.js` and add the YouTube videos. 

In the future, it may be a good idea for DAppNode to change the source of origin for these YouTube videos to their own existing YouTube channel (to maintain general consistency). 

**Testing:**
Changes have been tested across two development environments on two platforms. There are no compile errors. Feel free to try for yourself. 

**In reference to:**
* [DAppNode Issue #36](https://github.com/dappnode/DAppNode/issues/36)

Thanks,

Anish
