### PR TITLE
Fix wrong Linux redirect (Issue 25)

### DIFF
--- a/src/HiddenRedirector.js
+++ b/src/HiddenRedirector.js
@@ -36,5 +36,7 @@ function guessUserPlatform() {
     return "macos";
   } else if (osName.includes("windows")) {
     return "windows";
+  } else if (osName.includes("linux")) {
+    return "linux";
   }
 }


### PR DESCRIPTION
Closes #25 which I spotted today. The fix is straightforward, completing the `guessUserPlatform` function by adding an if statement for Linux.