### PR TITLE
Adding Android video.

### DIFF
--- a/src/Instructions/Android.js
+++ b/src/Instructions/Android.js
@@ -1,11 +1,14 @@
 import React, { Component } from "react";
 import Credential from "./Credential";
+import VideoInstructions from "./VideoInstructions";
 
 export default class Android extends Component {
   render() {
     // <Credential tag={'server'}/>
     return (
       <div>
+        <VideoInstructions platform={"Android"} />
+
         <h4>Android setup guide</h4>
         <hr className="my-4" />
         <ol className="ListInstructions">

--- a/src/Instructions/VideoInstructions.js
+++ b/src/Instructions/VideoInstructions.js
@@ -2,7 +2,8 @@ import React, { Component } from "react";
 
 const youtubeLink = {
   'Windows 7, Vista and XP': "https://www.youtube.com/embed/wGWrXofjIyo",
-  'Windows 10 and 8.x': "https://www.youtube.com/embed/kq1NFCbR1wI"
+  'Windows 10 and 8.x': "https://www.youtube.com/embed/kq1NFCbR1wI",
+  'Android': "https://www.youtube.com/embed/g5Ic1tcg_OY"
 };
 
 export default class VideoInstructions extends Component {


### PR DESCRIPTION
While https://github.com/dappnode/DAppNode/issues/37 was closed, the Android installation video was never hosted and merged into DAppNode_OTP. 

This commit adds the hosted video (under the same DAppNode youtube account used by the Windows videos), and adds the embed link to `VideoInstructions.js` so that it can be displayed.