### PR TITLE
Adding chromebook video.

### DIFF
--- a/src/Instructions/Chromebook.js
+++ b/src/Instructions/Chromebook.js
@@ -1,11 +1,14 @@
 import React, { Component } from "react";
 import Credential from "./Credential";
+import VideoInstructions from "./VideoInstructions";
 
 export default class Chromebook extends Component {
   render() {
     // <Credential tag={'server'}/>
     return (
       <div>
+        <VideoInstructions platform={"Windows 7, Vista and XP"} />
+
         <h4>Chromebook setup guide</h4>
         <hr className="my-4" />
         <ol className="ListInstructions">

--- a/src/Instructions/VideoInstructions.js
+++ b/src/Instructions/VideoInstructions.js
@@ -2,7 +2,8 @@ import React, { Component } from "react";
 
 const youtubeLink = {
   'Windows 7, Vista and XP': "https://www.youtube.com/embed/wGWrXofjIyo",
-  'Windows 10 and 8.x': "https://www.youtube.com/embed/kq1NFCbR1wI"
+  'Windows 10 and 8.x': "https://www.youtube.com/embed/kq1NFCbR1wI",
+  'Chromebook': "https://www.youtube.com/watch?v=JNzDIMoaMSc"
 };
 
 export default class VideoInstructions extends Component {


### PR DESCRIPTION
Was adding in the Android instructions earlier today and noticed we didn't have a video guide for Chromebook instructions. 

So, I quickly whipped up a VM, installed Chrome OS, and recorded a video of the process: https://www.youtube.com/watch?v=JNzDIMoaMSc

Feel free to let me know if I should edit the video to include the user accessing their portal at the end (similar to the Windows videos). 

Also, might be a good idea to re-upload all the other videos to the official DAppNode YouTube account, and change their source of origin in `VideoInstructions.js`, so that everything is cohesive.

Thanks,

Anish